### PR TITLE
Add Counterparty MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[Counterparty MCP Server](https://github.com/XCP/mcp-server)** – Interact with [Counterparty](https://counterparty.io), the **token protocol on Bitcoin**. Query balances, assets, orders, dispensers, and compose/sign/broadcast transactions. 49 tools covering the full protocol.
+
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adds [Counterparty MCP Server](https://github.com/XCP/mcp-server) to the On-Chain Integration MCPs section.

[Counterparty](https://counterparty.io) is the token protocol built on Bitcoin — it enables creating and trading digital assets (tokens) directly on the Bitcoin blockchain. The MCP server provides 49 tools covering the full protocol:

- **24 query tools** — balances, assets, orders, dispensers, transactions
- **18 compose tools** — sends, DEX orders, dispensers, issuances, fair minting
- **4 Bitcoin tools** — sign, broadcast, fee estimation, decode
- **3 utility tools** — unpack, server info, raw API

Published on npm ([`@21e14/mcp-server`](https://www.npmjs.com/package/@21e14/mcp-server)) and the [official MCP Registry](https://registry.modelcontextprotocol.io). Zero config — no API keys required.