### PR TITLE
Add Azeth MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[Azeth MCP Server](https://github.com/azeth-protocol/mcp-server)** – Trust infrastructure for the machine economy — **non-custodial smart accounts (ERC-4337)**, x402 payments, on-chain reputation via **ERC-8004 trust registry**, and AI-native service discovery on Base.
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Add @azeth/mcp-server under On-Chain Integration MCPs — trust infrastructure for the machine economy with non-custodial ERC-4337 smart accounts, x402 payments, ERC-8004 on-chain reputation, and service discovery.

- **GitHub**: https://github.com/azeth-protocol/mcp-server
- **npm**: https://www.npmjs.com/package/@azeth/mcp-server
- **License**: MIT