### PR TITLE
Add Bitcoin MCP - 43 tools for Bitcoin Core AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[Bitcoin MCP](https://github.com/Bortlesboat/bitcoin-mcp)** – 43 tools for **Bitcoin Core** node interaction — fee estimation with USD conversion, mempool analysis, block data, mining stats, price feeds, and AI agent workflows with 6 prompts and 7 resources. Install via `pip install bitcoin-mcp` or use hosted via [Satoshi API](https://bitcoinsapi.com).
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
## Summary
- Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the On-Chain Integration MCPs section
- 43 tools, 6 prompts, 7 resources for querying Bitcoin Core/Knots nodes — fee estimation with USD conversion, mempool analysis, block data, mining stats, price feeds
- Install via `pip install bitcoin-mcp` or use hosted via [Satoshi API](https://bitcoinsapi.com)
- Listed on the [official Anthropic MCP Registry](https://github.com/modelcontextprotocol/servers) and [PyPI](https://pypi.org/project/bitcoin-mcp/)