### PR TITLE
Add ThryxProtocol MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[ThryxProtocol MCP Server](https://github.com/lordbasilaiassistant-sudo/thryx-mcp-server)** – AI Agent Launchpad on **Base**. Launch tokens ($0.01 gas), trade bonding curves, claim fees, and check token safety. **13 MCP tools**, verified Diamond proxy (EIP-2535).
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adding ThryxProtocol MCP Server - an AI Agent Launchpad on Base mainnet. 13 tools for launching tokens, trading on bonding curves, claiming fees, and checking token safety. Verified Diamond proxy (EIP-2535) at 0x2F77b40c124645d25782CfBdfB1f54C1d76f2cCe. Published on npm as @thryx/mcp-server.