### PR TITLE
Add WAIaaS — self-hosted wallet daemon for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS)** – Self-hosted wallet daemon for AI agents. **59+ MCP tools** for wallet management, DeFi (swap/lend/stake/bridge/perp), NFT, and x402 payments across **EVM + Solana**. Default-deny policy engine, spending limits, human approval, kill switch. Keys never leave the daemon.
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adds [WAIaaS](https://waiaas.ai) — a self-hosted wallet daemon for AI agents.

- **Multi-chain**: EVM + Solana unified API
- **59+ MCP tools**: wallet management, DeFi, NFT, x402, ERC-4337
- **Security**: default-deny policy engine, spending limits, human approval, kill switch
- **Self-hosted**: runs locally, no third-party API keys

GitHub: https://github.com/minhoyoo-iotrust/WAIaaS