### PR TITLE
Add Ponzu MCP — DeFi token launchpad server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[deBridge MCP](https://github.com/debridge-finance/debridge-mcp)** – Enables AI agents to find optimal **cross-chain swap routes**, check fees, and initiate non-custodial trades across Ethereum, Solana, Arbitrum, Base, BNB Chain, Polygon, Optimism, Avalanche, Linea, Berachain, Tron, Cronos, Gnosis, Monad, Sonic, Flow, HyperEVM, Sei, Story, Injective, Abstract, MegaETH, Mantle, Plasma, Zilliqa, Sophon, Bob, Neon, and other chains.
 - **[Arcadia Finance](https://github.com/arcadia-finance/mcp-server)** - Manage concentrated liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Optimism.
 - **[WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS)** – Self-hosted wallet daemon for AI agents. **59+ MCP tools** for wallet management, DeFi (swap/lend/stake/bridge/perp), NFT, and x402 payments across **EVM + Solana**. Default-deny policy engine, spending limits, human approval, kill switch. Keys never leave the daemon.
+- **[Ponzu MCP (PonzuTech)](https://github.com/PonzuTech/ponzu_mcp)** – MCP server for the **Ponzu token launchpad** on Ethereum, Base, and BNB Chain. 17 tools for **token deployment**, presale participation, DEX trading, and **LP farming** with diamond hand vesting.
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adds Ponzu MCP — an MCP server with 17 tools for the Ponzu token launchpad. Supports deploying tokens, presale participation, DEX trading, and LP farming on Ethereum, Base, and BNB Chain.

- npm: https://www.npmjs.com/package/@ponzu_app/mcp
- GitHub: https://github.com/PonzuTech/ponzu_mcp
- Homepage: https://ponzu.app