### PR TITLE
Add bitcoin-mcp (49 Bitcoin tools for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[GOAT On-Chain Agent MCP](https://github.com/goat-sdk/goat/tree/main/typescript/examples/by-framework/model-context-protocol)** – "One MCP to rule all chains" with **200+ on-chain actions** across Ethereum, Solana, and Base. Fetch data and execute smart contract interactions.
 - **[Solana MCP (SendAI)](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** – Dedicated **Solana MCP server** with **40+ Solana-specific actions**, including SPL token management and account data.
 - **[Blockchain MCP powered by Tatum](https://github.com/tatumio/blockchain-mcp)** – A Model Context Protocol (MCP) server that provides access to the Tatum Blockchain Data API and RPC Gateway, enabling any LLM to read and write blockchain data across 130+ networks.
+- **[Bitcoin MCP (Bortlesboat)](https://github.com/Bortlesboat/bitcoin-mcp)** – 49 Bitcoin tools for AI agents — fee intelligence, mempool analysis, blocks, transactions, mining, price. Zero config, auto-falls back to hosted API. `pip install bitcoin-mcp`. 116 tests, MIT licensed.
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the On-Chain Integration MCPs section.

- **50 standard Bitcoin tools** for fee intelligence, mempool analysis, blocks, transactions, mining, price, and related workflows
- **Six prompts** and **eight resources**
- Supports Bitcoin Core and explicitly configured Satoshi API-compatible backends
- MIT licensed
- Install: `pip install bitcoin-mcp`