### PR TITLE
Add sui-mcp-server — 53-tool Sui MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[deBridge MCP](https://github.com/debridge-finance/debridge-mcp)** – Enables AI agents to find optimal **cross-chain swap routes**, check fees, and initiate non-custodial trades across Ethereum, Solana, Arbitrum, Base, BNB Chain, Polygon, Optimism, Avalanche, Linea, Berachain, Tron, Cronos, Gnosis, Monad, Sonic, Flow, HyperEVM, Sei, Story, Injective, Abstract, MegaETH, Mantle, Plasma, Zilliqa, Sophon, Bob, Neon, and other chains.
 - **[Arcadia Finance](https://github.com/arcadia-finance/mcp-server)** - Manage concentrated liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Optimism.
 - **[WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS)** – Self-hosted wallet daemon for AI agents. **59+ MCP tools** for wallet management, DeFi (swap/lend/stake/bridge/perp), NFT, and x402 payments across **EVM + Solana**. Default-deny policy engine, spending limits, human approval, kill switch. Keys never leave the daemon.
+- **[sui-mcp-server](https://github.com/ExpertVagabond/sui-mcp-server)** – **53-tool MCP server for Sui blockchain** — wallets, DeFi, Move contracts, staking, SuiNS, and analytics. [![npm](https://img.shields.io/npm/v/sui-mcp-server)](https://www.npmjs.com/package/sui-mcp-server)
+
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
## Summary

- Adds [sui-mcp-server](https://github.com/ExpertVagabond/sui-mcp-server) to the On-Chain Integration MCPs section
- 53-tool MCP server for the Sui blockchain covering wallets, DeFi, Move contracts, staking, SuiNS, and analytics
- Published on npm: [sui-mcp-server](https://www.npmjs.com/package/sui-mcp-server)