### PR TITLE
Add SatoshiData Wallet Intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ MCP servers designed for crypto transactions, payments, and market data.
 MCP servers providing analytics, compliance, and security insights for blockchain networks.
 
 - **[Heurist Mesh MCP](https://github.com/heurist-network/heurist-mesh-mcp-server)** – Provides **on-chain analytics**, token metrics, and security insights for smart contracts.
+- **[SatoshiData Wallet Intelligence](https://smithery.ai/server/@wrbtc/satoshidata-wallet-intel)** – Bitcoin wallet intelligence MCP with **20 tools** — entity labels, trust scores, and on-chain analytics across **33M+ labeled addresses**. L402 Lightning payments, no signup required. [GitHub](https://github.com/wrbtc) · [API](https://satoshidata.ai)
 - **[Ergo Explorer MCP](https://github.com/marctheshark3/ergo-mcp)** – Queries **Ergo blockchain data**, including transaction history and forensic analysis of addresses.
 - **[Etherscan MCP](https://github.com/crazyrabbitLTC/mcp-etherscan-server)** – Fetch **Ethereum blockchain data** using Etherscan’s API, including token balances, ENS lookups, and contract interactions.
 - **[Philidor DeFi Vault Risk Analytics](https://github.com/Philidor-Labs/philidor-mcp)** – Search and score **700+ DeFi vaults** across Morpho, Aave, Spark, Yearn, Beefy, Compound, and Uniswap. Three-vector risk framework (Asset 40%, Platform 40%, Governance 20%) with Prime/Core/Edge tier classification. Remote server at [mcp.philidor.io](https://mcp.philidor.io) — no API key needed.


### PR DESCRIPTION
## Summary

Adds [SatoshiData Wallet Intelligence](https://smithery.ai/server/@wrbtc/satoshidata-wallet-intel) to the Blockchain Analytics & Security section.

- **20 MCP tools** for Bitcoin wallet intelligence
- **33M+ labeled addresses** with entity labels, trust scores, and on-chain analytics
- L402 Lightning payments — no signup or API key required
- Available on [Smithery](https://smithery.ai/server/@wrbtc/satoshidata-wallet-intel) and via [satoshidata.ai](https://satoshidata.ai)

Thanks for maintaining this list!