### PR TITLE
Add PreReason MCP to Blockchain Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[CoinStats MCP](https://github.com/CoinStatsHQ/coinstats-mcp)** – Provides access to cryptocurrency market data, portfolio tracking, and news.
 - **[Octav API MCP](https://github.com/Octav-Labs/octav-api-mcp)** – Multi-chain crypto portfolio tracking MCP server. Access wallet holdings, DeFi protocol positions, transaction history, and token analytics across 20+ blockchains directly from Claude.
 - **[Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp)** - Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics. Hive's remote mcp server guide [remote server](https://hiveintelligence.xyz/crypto-mcp).
+- **[PreReason MCP](https://github.com/PreReason/mcp)** – Context API for financial agents. Delivers pre-analyzed market briefings with regime classification, confidence scores, and cross-asset correlations. 17 briefings spanning BTC on-chain metrics, macro indicators (Fed, M2, Treasury yields), and equity index signals. Free tier with 6 briefings at 60 req/hr.
 
 ---
 


### PR DESCRIPTION
Adds PreReason to the Blockchain Data section.

PreReason serves pre-analyzed market briefings through MCP rather than raw data. It covers BTC on-chain metrics, macro indicators, and cross-asset regime data across 17 briefings. Agents get trend direction, confidence scores, and causal narratives instead of having to interpret numbers themselves.

- GitHub: [PreReason/mcp](https://github.com/PreReason/mcp)
- npm: [@prereason/mcp](https://www.npmjs.com/package/@prereason/mcp)
- License: MIT