### PR TITLE
Add ZKProofport MCP (ZK identity proofs via x402 on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ MCP servers designed for crypto transactions, payments, and market data.
 - **[Lightning Network MCP](https://github.com/AbdelStark/lightning-mcp)** – Enables AI-driven **Bitcoin payments via Lightning Network**, supporting invoice payments and balance queries.
 - **[Zebedee ZBD MCP](https://github.com/zebedeeio/zbd-mcp-server)** – Connects AI agents to **Bitcoin Lightning** for micropayments and rewards.
 - **[Base USDC Transfer MCP](https://github.com/magnetai/mcp-free-usdc-transfer)** – AI-driven **USDC transfers on Base chain** using Coinbase MPC wallets (gas-free transfers).
+- **[ZKProofport MCP](https://github.com/zkproofport/proofport-ai)** – Zero-knowledge proof generation MCP server paid via **x402 USDC on Base**. Enables AI agents to prove identity claims (Coinbase KYC, Country, Google OIDC, Workspace, MS 365) without revealing personal information. AWS Nitro Enclave TEE proving, ERC-8004 registered. NPM: `@zkproofport-ai/mcp`.
 
 ---
 


### PR DESCRIPTION
Adds ZKProofport MCP to the **Crypto Payments MCPs** section.

ZKProofport is a zero-knowledge proof generation MCP server that enables AI agents to prove identity claims (Coinbase KYC, Country, Google OIDC, Google Workspace, Microsoft 365) without revealing personal information. Proof generation is paid via x402 USDC payments on Base.

**Why it fits the list:**
- **x402 + Base USDC payments** native
- **MCP server** with `zkproofport-prove` CLI for AI agents
- **AWS Nitro Enclave TEE** for trusted server-side proving
- **Noir circuits** (Aztec) for the ZK layer
- **ERC-8004 registered**: token ID 25331 on Base Mainnet
- **Open source MIT**: `@zkproofport-ai/mcp` (NPM)

**Reference application**: [OpenStoa](https://github.com/zkproofport/openstoa) — won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects).