### PR TITLE
Add AlgoVoi multi-chain payment gateway to Crypto Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ MCP servers designed for crypto transactions, payments, and market data.
 - **[Lightning Network MCP](https://github.com/AbdelStark/lightning-mcp)** – Enables AI-driven **Bitcoin payments via Lightning Network**, supporting invoice payments and balance queries.
 - **[Zebedee ZBD MCP](https://github.com/zebedeeio/zbd-mcp-server)** – Connects AI agents to **Bitcoin Lightning** for micropayments and rewards.
 - **[Base USDC Transfer MCP](https://github.com/magnetai/mcp-free-usdc-transfer)** – AI-driven **USDC transfers on Base chain** using Coinbase MPC wallets (gas-free transfers).
+- **[AlgoVoi](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters)** – Multi-chain payment gateway MCP supporting **7 chains** (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo). Creates hosted USDC checkouts and verifies on-chain settlement via x402, MPP, and AP2 protocols. Solana flow uses native Solana Pay `reference` pubkey binding.
 
 ---
 


### PR DESCRIPTION
Adds AlgoVoi to the Crypto Payments MCPs section.

Differentiates from existing entries (Lightning, Base USDC Transfer) by spanning 7 chains on a single endpoint - Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo - and exposing x402, MPP, and AP2 payment protocols simultaneously. Solana uses Solana Pay `reference` pubkey binding for cryptographic tx<->order correlation. Live at api.algovoi.co.uk. Install via `npx @algovoi/mcp-server`.

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*