### PR TITLE
Add Haiku MCP Server - DeFi operations across 22 chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[deBridge MCP](https://github.com/debridge-finance/debridge-mcp)** – Enables AI agents to find optimal **cross-chain swap routes**, check fees, and initiate non-custodial trades across Ethereum, Solana, Arbitrum, Base, BNB Chain, Polygon, Optimism, Avalanche, Linea, Berachain, Tron, Cronos, Gnosis, Monad, Sonic, Flow, HyperEVM, Sei, Story, Injective, Abstract, MegaETH, Mantle, Plasma, Zilliqa, Sophon, Bob, Neon, and other chains.
 - **[Arcadia Finance](https://github.com/arcadia-finance/mcp-server)** - Manage concentrated liquidity positions with leverage, automated rebalancing, and yield optimization on Base and Optimism.
 - **[WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS)** – Self-hosted wallet daemon for AI agents. **59+ MCP tools** for wallet management, DeFi (swap/lend/stake/bridge/perp), NFT, and x402 payments across **EVM + Solana**. Default-deny policy engine, spending limits, human approval, kill switch. Keys never leave the daemon.
+- **[Haiku MCP Server](https://github.com/Haiku-Trading/haiku-mcp-server)** – Multi-chain DeFi server supporting **22 blockchain networks** including **Ethereum, Arbitrum, Base, Polygon, Optimism, Avalanche, and BSC**. Execute **swaps, lending, vaults, LP positions, and cross-chain bridges**. Includes **yield discovery and portfolio analysis**. Free, no API key required.
+
 ---
 
 ## 📊 Blockchain Data


### PR DESCRIPTION
Adding Haiku MCP Server - a comprehensive multi-chain DeFi integration server.

This server provides AI agents with the ability to execute DeFi operations across 22 blockchain networks, including Ethereum, Arbitrum, Base, Polygon, Optimism, Avalanche, BSC, and more.

Core capabilities:
- Token swaps via aggregators
- Lending and borrowing operations
- Vault management (deposits/withdrawals)
- Liquidity pool positions
- Cross-chain bridge transactions
- Yield discovery and portfolio analysis

The server offers 7 tools for comprehensive DeFi operations and requires no API key, making it freely accessible to developers.

- npm: https://www.npmjs.com/package/haiku-mcp-server
- GitHub: https://github.com/Haiku-Trading/haiku-mcp-server