### PR TITLE
Add The Stall — x402 pay-per-call MCP with 194 AI data tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These MCP servers connect AI models directly to blockchain networks, enabling ac
 - **[CoinStats MCP](https://github.com/CoinStatsHQ/coinstats-mcp)** – Provides access to cryptocurrency market data, portfolio tracking, and news.
 - **[Octav API MCP](https://github.com/Octav-Labs/octav-api-mcp)** – Multi-chain crypto portfolio tracking MCP server. Access wallet holdings, DeFi protocol positions, transaction history, and token analytics across 20+ blockchains directly from Claude.
 - **[Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp)** - Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics. Hive's remote mcp server guide [remote server](https://hiveintelligence.xyz/crypto-mcp).
+- **[The Stall](https://github.com/thebrierfox/the-stall)** – x402 pay-per-call MCP server with **183 AI data tools** covering DeFi analytics, on-chain data (Base/ETH/BSC), crypto fear/greed index, whale radar, token security scoring, stablecoin watch, EVM log events, transaction explainer, DEX quotes, and social momentum signals. USDC micropayments on Base — no API keys needed. Remote server at [the-stall.intuitek.ai](https://the-stall.intuitek.ai).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **The Stall** to the Blockchain Data section — an x402 pay-per-call MCP server with 194 AI data capabilities spanning DeFi analytics, on-chain data (Base/ETH/BSC), crypto fear/greed index, whale radar, token security scoring, stablecoin watch, EVM log events, transaction explainer, DEX quotes, and social momentum signals.

**Key details:**
- 192 AI tools over a single MCP endpoint
- No API keys required — USDC micropayments on Base via x402 protocol
- Remote server live at https://the-stall.intuitek.ai
- GitHub: https://github.com/thebrierfox/the-stall

The Stall fits the Blockchain Data section alongside Hive Intelligence and the CoinGecko/CoinMarketCap servers, offering a broad set of on-chain and market data capabilities accessible without subscriptions.